### PR TITLE
GH-4482 Replace Datatype IRI to CoreDatatype in AbstractLiteral

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
@@ -190,9 +190,9 @@ public abstract class AbstractLiteral implements Literal {
 
 				.orElseGet(() -> {
 
-					final IRI datatype = getDatatype();
+					final CoreDatatype datatype = getCoreDatatype();
 
-					return datatype.equals(CoreDatatype.XSD.STRING) ? label
+					return CoreDatatype.XSD.STRING.equals(datatype) ? label
 							: label + "^^<" + datatype.stringValue() + ">";
 
 				});


### PR DESCRIPTION
GitHub issue resolved: #4482

Briefly describe the changes proposed in this PR:

I replace the IRI by CoreDatatype, I hope it is fine without any test knowing how trivial it is.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

